### PR TITLE
Updated the grid props for grid items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 .docz
 site
+.vscode/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-props",
-  "version": "0.16.0",
+  "version": "0.15.0",
   "description": "Inspired by styled-system, a responsive, theme-based style props for building design systems with React.",
   "author": "Rogin Farrer",
   "homepage": "https://github.com/system-props/system-props#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-props",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Inspired by styled-system, a responsive, theme-based style props for building design systems with React.",
   "author": "Rogin Farrer",
   "homepage": "https://github.com/system-props/system-props#readme",

--- a/src/props/grid/index.ts
+++ b/src/props/grid/index.ts
@@ -25,7 +25,15 @@ export const grid: PropConfigCollection = {
   gridTemplateColumns: true,
   gridTemplateRows: true,
   gridTemplateAreas: true,
+  // Grid Item props
   gridArea: true,
+  gridColumnStart: true,
+  gridColumnEnd: true,
+  gridRowStart: true,
+  gridRowEnd: true,
+  justifySelf: true,
+  alignSelf: true,
+  placeSelf: true
 };
 
 export default grid;


### PR DESCRIPTION
Updated the grid props for grid items to add support for the following css properties: 
- grid-column-start
- grid-column-end
- grid-row-start
- grid-row-end
- justify-self
- align-self
- place-self

I also updated the package version to v0.16.0