### PR TITLE
Add basic support for custom get function in config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ['no-only-tests'],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-props",
-  "version": "0.16.0",
+  "version": "0.17.0-0",
   "description": "Inspired by styled-system, a responsive, theme-based style props for building design systems with React.",
   "author": "Rogin Farrer",
   "homepage": "https://github.com/system-props/system-props#readme",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.1",
     "csstype": "^3.0.5",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.3.0",
     "np": "^6.5.0",

--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -16,6 +16,7 @@ test('package has expected exports', () => {
       "gridItem",
       "layout",
       "margin",
+      "memoizeGet",
       "padding",
       "position",
       "propNames",
@@ -24,6 +25,7 @@ test('package has expected exports', () => {
       "shouldForwardProp",
       "space",
       "styledSystemLayout",
+      "tokenGet",
       "typography",
     ]
   `);

--- a/src/core/createStyleFunction.ts
+++ b/src/core/createStyleFunction.ts
@@ -9,15 +9,15 @@ import {
 } from '../types';
 import * as CSS from 'csstype';
 
-const getValue: Transform = (get) => (value, scale, _props, strict) => {
-  return get(scale, value, strict === true ? undefined : value);
+const defaultTransform: Transform = ({ path, object, strict, get }) => {
+  return get(object, path, strict === true ? undefined : path);
 };
 
 export const createStyleFunction: StyleFunction = ({
   properties,
   property,
   scale,
-  transform = getValue,
+  transform = defaultTransform,
   defaultScale,
   get,
 }) => {
@@ -36,7 +36,13 @@ export const createStyleFunction: StyleFunction = ({
     const result: Record<string, any> = {};
 
     let n = value;
-    n = transform(get)(value, scale, props, cache.strict);
+    n = transform({
+      path: value,
+      object: scale,
+      props,
+      strict: cache.strict,
+      get,
+    });
 
     if (n === null) {
       return result;

--- a/src/core/createStyleFunction.ts
+++ b/src/core/createStyleFunction.ts
@@ -1,24 +1,31 @@
-import { memoizedGet } from './get';
-import { Props, PropertyConfig, SystemConfig, Cache } from '../types';
+// import { memoizedGet } from './get';
+import {
+  Props,
+  // PropertyConfig,
+  // SystemConfig,
+  Cache,
+  StyleFunction,
+  Transform,
+} from '../types';
 import * as CSS from 'csstype';
 
-const getValue = (
-  value: string | number,
-  scale: any,
-  _props: Props,
-  strict: boolean
-) => {
-  return memoizedGet(scale, value, strict === true ? undefined : value);
+const getValue: Transform = (get) => (value, scale, _props, strict) => {
+  return get(scale, value, strict === true ? undefined : value);
 };
 
-export const createStyleFunction = ({
+export const createStyleFunction: StyleFunction = ({
   properties,
   property,
   scale,
   transform = getValue,
   defaultScale,
-}: PropertyConfig): SystemConfig => {
+  get,
+}) => {
   const _properties = properties || [property];
+
+  if (typeof get !== 'function') {
+    throw new Error('');
+  }
 
   const systemConfig = (
     value: number | string,
@@ -29,7 +36,7 @@ export const createStyleFunction = ({
     const result: Record<string, any> = {};
 
     let n = value;
-    n = transform(value, scale, props, cache.strict);
+    n = transform(get)(value, scale, props, cache.strict);
 
     if (n === null) {
       return result;

--- a/src/core/createSystem.ts
+++ b/src/core/createSystem.ts
@@ -1,6 +1,6 @@
 import { parseResponsiveStyle, parseResponsiveObject } from './parseResponsive';
 import { createStyleFunction } from './createStyleFunction';
-import { memoizedGet as get } from './get';
+import { memoizedGet as defaultGet, get } from './get';
 import {
   SystemProp,
   SystemConfig,
@@ -8,6 +8,7 @@ import {
   Props,
   SomeObject,
   Cache,
+  Get,
 } from '../types';
 import { sort } from './sort';
 import { merge } from './merge';
@@ -159,28 +160,32 @@ export const createParser = (
 export const createSystem = ({
   strict = false,
   pseudoSelectors = defaultPseudos,
+  get = defaultGet,
 }: {
   pseudoSelectors?: Record<string, string>;
   strict?: boolean;
+  get?: Get;
 } = {}) => {
-  const system = (args: PropConfigCollection) => {
+  const system = (...args: PropConfigCollection[]) => {
     const config: { [x: string]: SystemConfig } = {};
-    Object.keys(args).forEach((key) => {
-      const conf = args[key];
-      if (conf === true) {
-        // shortcut definition
-        config[key] = createStyleFunction({
-          property: key as keyof CSS.Properties,
-          scale: key,
-        });
-        return;
-      }
-      if (typeof conf === 'function') {
-        return;
-      }
-      config[key] = createStyleFunction(conf);
+    args.forEach((arg) => {
+      Object.keys(arg).forEach((key) => {
+        const conf = arg[key];
+        if (conf === true) {
+          // shortcut definition
+          config[key] = createStyleFunction({
+            property: key as keyof CSS.Properties,
+            scale: key,
+            get,
+          });
+          return;
+        }
+        if (typeof conf === 'function') {
+          return;
+        }
+        config[key] = createStyleFunction({ ...conf, get });
+      });
     });
-
     const parser = createParser(config, pseudoSelectors, strict);
     return parser;
   };

--- a/src/core/createSystem.ts
+++ b/src/core/createSystem.ts
@@ -166,25 +166,23 @@ export const createSystem = ({
   strict?: boolean;
   get?: Get;
 } = {}) => {
-  const system = (...args: PropConfigCollection[]) => {
+  const system = (arg: PropConfigCollection) => {
     const config: { [x: string]: SystemConfig } = {};
-    args.forEach((arg) => {
-      Object.keys(arg).forEach((key) => {
-        const conf = arg[key];
-        if (conf === true) {
-          // shortcut definition
-          config[key] = createStyleFunction({
-            property: key as keyof CSS.Properties,
-            scale: key,
-            get,
-          });
-          return;
-        }
-        if (typeof conf === 'function') {
-          return;
-        }
-        config[key] = createStyleFunction({ ...conf, get });
-      });
+    Object.keys(arg).forEach((key) => {
+      const conf = arg[key];
+      if (conf === true) {
+        // shortcut definition
+        config[key] = createStyleFunction({
+          property: key as keyof CSS.Properties,
+          scale: key,
+          get,
+        });
+        return;
+      }
+      if (typeof conf === 'function') {
+        return;
+      }
+      config[key] = createStyleFunction({ ...conf, get });
     });
     const parser = createParser(config, pseudoSelectors, strict);
     return parser;

--- a/src/core/get.ts
+++ b/src/core/get.ts
@@ -1,7 +1,8 @@
-interface Get {
-  (obj?: any, path?: any, fallback?: any): any;
-}
+import { Get } from '../types';
 
+/**
+ * Generic "get" function
+ */
 export const get: Get = (object, path, defaultValue) => {
   if (!object) {
     return defaultValue;
@@ -26,10 +27,13 @@ export const get: Get = (object, path, defaultValue) => {
   return result === undefined ? defaultValue : result;
 };
 
+/**
+ * Requires path to have '$' prefixing the value
+ */
 export const betterGet: Get = (object, path, defaultValue) => {
-  let result = get(object, path);
+  let result;
 
-  if (!result && typeof path === 'string' && path.startsWith('$')) {
+  if (typeof path === 'string' && path.startsWith('$')) {
     result = get(object, path.slice(1));
   }
 

--- a/src/core/get.ts
+++ b/src/core/get.ts
@@ -30,7 +30,7 @@ export const get: Get = (object, path, defaultValue) => {
 /**
  * Requires path to have '$' prefixing the value
  */
-export const betterGet: Get = (object, path, defaultValue) => {
+export const tokenGet: Get = (object, path, defaultValue) => {
   let result;
 
   if (typeof path === 'string' && path.startsWith('$')) {
@@ -40,7 +40,7 @@ export const betterGet: Get = (object, path, defaultValue) => {
   return result === undefined ? defaultValue : result;
 };
 
-export const memoize = (fn: Get) => {
+export const memoizeGet = (fn: Get) => {
   let cache = new WeakMap();
 
   const memoizedFn: Get = (obj, path, fallback) => {
@@ -68,4 +68,4 @@ export const memoize = (fn: Get) => {
   return memoizedFn;
 };
 
-export const memoizedGet = memoize(betterGet);
+export const memoizedGet = memoizeGet(tokenGet);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,2 @@
-export { betterGet as get } from './get';
+export { tokenGet, memoizeGet, get, memoizedGet } from './get';
 export { createSystem } from './createSystem';

--- a/src/core/tests/get.test.ts
+++ b/src/core/tests/get.test.ts
@@ -1,6 +1,4 @@
-import { betterGet, memoize } from '../get';
-
-const get = betterGet;
+import { get, betterGet, memoize } from '../get';
 
 test('returns a deeply nested value', () => {
   const a = get(
@@ -40,7 +38,7 @@ test('returns 0 index items', () => {
 });
 
 test('returns number values with $', () => {
-  const a = get([0, 4, 8], '$2');
+  const a = betterGet([0, 4, 8], '$2');
   expect(a).toBe(8);
 });
 

--- a/src/core/tests/get.test.ts
+++ b/src/core/tests/get.test.ts
@@ -1,4 +1,4 @@
-import { get, betterGet, memoize } from '../get';
+import { get, tokenGet, memoizeGet } from '../get';
 
 test('returns a deeply nested value', () => {
   const a = get(
@@ -38,7 +38,7 @@ test('returns 0 index items', () => {
 });
 
 test('returns number values with $', () => {
-  const a = betterGet([0, 4, 8], '$2');
+  const a = tokenGet([0, 4, 8], '$2');
   expect(a).toBe(8);
 });
 
@@ -49,7 +49,7 @@ test('memoize', () => {
     },
   };
   const _get = jest.fn(() => true);
-  const memoizedGet = memoize(_get);
+  const memoizedGet = memoizeGet(_get);
   expect(memoizedGet(obj, 'colors.blue.3')).toStrictEqual(true);
   expect(memoizedGet(obj, 'colors.blue.3')).toStrictEqual(true);
   expect(memoizedGet(obj, 'colors.blue.3')).toStrictEqual(true);

--- a/src/core/tests/parser.test.ts
+++ b/src/core/tests/parser.test.ts
@@ -40,11 +40,11 @@ test('parses pseudo selectors', () => {
   const styles = parser({
     theme,
     _hover: {
-      color: 'secondary',
-      fontSize: [2, 1],
+      color: '$secondary',
+      fontSize: ['$2', '$1'],
     },
-    fontSize: [1, 2, 3],
-    color: ['primary', null, 'secondary'],
+    fontSize: ['$1', '$2', '$3'],
+    color: ['$primary', null, '$secondary'],
   });
   expect(styles).toEqual({
     color: 'rebeccapurple',
@@ -69,8 +69,8 @@ test('parses pseudo selectors', () => {
 test('uses breakpoints', () => {
   const styles = parser({
     theme,
-    fontSize: [1, 2, 3],
-    color: ['primary', null, 'secondary'],
+    fontSize: ['$1', '$2', '$3'],
+    color: ['$primary', null, '$secondary'],
   });
   expect(styles).toEqual({
     color: 'rebeccapurple',
@@ -89,8 +89,8 @@ test('uses breakpoints', () => {
 test('does *not* use dynamically changed breakpoints', () => {
   const styles = parser({
     theme: { ...theme, breakpoints: ['11em', '22em', '33em'] },
-    fontSize: [1, 2, 3],
-    color: ['primary', null, 'secondary'],
+    fontSize: ['$1', '$2', '$3'],
+    color: ['$primary', null, '$secondary'],
   });
   expect(styles).toEqual({
     color: 'rebeccapurple',
@@ -167,26 +167,6 @@ test.skip('uses dynamically changed breakpoints', () => {
   });
 });
 
-// // Skipped since I moved breakpoints into the createSystem signature
-// test.skip('throws an error if no "breakpoints" entry found in theme', () => {
-//   expect(() =>
-//     parser({
-//       theme: {
-//         disableSystemPropsCache: true,
-//         colors: {
-//           primary: 'rebeccapurple',
-//           secondary: 'papayawhip',
-//         },
-//         fontSize: [0, 4, 8, 16],
-//       },
-//       fontSize: [1, 2, 3],
-//       color: ['primary', null, 'secondary'],
-//     })
-//   ).toThrowErrorMatchingInlineSnapshot(
-//     `"The system props parser could not find a \`breakpoints\` property in the theme object, which is required for responsive styles to work. Make sure that the theme object has a breakpoints property."`
-//   );
-// });
-
 test('parses raw function values', () => {
   // flush cache from previous tests
   const styles = parser({
@@ -201,7 +181,7 @@ test('parses raw function values', () => {
       color(t: typeof theme) {
         return t.colors.secondary;
       },
-      fontSize: 2,
+      fontSize: '$2',
     },
   });
   expect(styles).toEqual({

--- a/src/core/tests/system.test.ts
+++ b/src/core/tests/system.test.ts
@@ -129,8 +129,8 @@ test('gets values from theme', () => {
       },
       space: [0, 6, 12, 24, 48, 96],
     },
-    mx: ['0', '1', '2', '3'],
-    color: ['primary', 'black'],
+    mx: ['$0', '$1', '$2', '$3'],
+    color: ['$primary', 'black'],
   });
   expect(style).toEqual({
     color: 'tomato',
@@ -176,8 +176,8 @@ test('if strict, only allows theme values', () => {
       },
       space: [0, 6, 12, 24],
     },
-    mx: ['0', '1', '2', '3', '4'],
-    color: ['primary', 'black'],
+    mx: ['$0', '$1', '$2', '$3', '$4'],
+    color: ['$primary', 'black'],
     bg: 'blue',
   });
   expect(style).toEqual({
@@ -212,7 +212,7 @@ test('gets 0 index values from theme', () => {
       breakpoints,
       sizes: [24, 48],
     },
-    width: '0',
+    width: '$0',
   });
   expect(style).toEqual({ width: 24 });
 });
@@ -333,7 +333,7 @@ test('sorts media queries when responsive object values are used', () => {
   ]);
 });
 
-test.only('supports custom get function', () => {
+test('supports custom get function', () => {
   const system = createSystem({ get });
   const parser = system({
     margin: true,

--- a/src/core/tests/system.test.ts
+++ b/src/core/tests/system.test.ts
@@ -1,4 +1,5 @@
 import { createSystem } from '../createSystem';
+import { get } from '../get';
 
 const breakpoints = [40, 52, 64].map((n) => n + 'em');
 
@@ -246,7 +247,7 @@ test('skips null values in arrays', () => {
   });
 });
 
-test.only('includes single property functions', () => {
+test('includes single property functions', () => {
   const system = createSystem();
   const parser = system({
     color: true,
@@ -332,19 +333,35 @@ test('sorts media queries when responsive object values are used', () => {
   ]);
 });
 
-// test('transforms values', () => {
-//   const system = createSystem({ breakpoints });
-//   const parser = system({
-//     margin: {
-//       property: 'margin',
-//       transform: (n, scale, props) => {
-//         const m = props.multiply || 1;
-//         return m * n;
-//       },
-//     },
-//   });
-//   const a = parser({ margin: 8 });
-//   const b = parser({ margin: 12, multiply: 2 });
-//   expect(a).toEqual({ margin: 8 });
-//   expect(b).toEqual({ margin: 24 });
-// });
+test.only('supports custom get function', () => {
+  const system = createSystem({ get });
+  const parser = system({
+    margin: true,
+    padding: true,
+    backgroundColor: { property: 'backgroundColor', scale: 'colors' },
+    color: { property: 'color', scale: 'colors' },
+  });
+  const styles = parser({
+    theme: {
+      systemPropsCacheKey: true,
+      colors: {
+        red: '#ff0000',
+        blue: '#0000ff',
+        green: '#00ff00',
+      },
+      margin: {
+        250: '2px',
+        500: '4px',
+        1000: '8px',
+      },
+    },
+    color: 'red',
+    backgroundColor: 'green',
+    margin: 250,
+  });
+  expect(styles).toStrictEqual({
+    color: '#ff0000',
+    backgroundColor: '#00ff00',
+    margin: '2px',
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { betterGet as get } from './core/get';
+export { memoizeGet, get, tokenGet } from './core/get';
 export { createSystem } from './core/createSystem';
 
 export * from './props';

--- a/src/props/border/borderShorthandTransform.ts
+++ b/src/props/border/borderShorthandTransform.ts
@@ -1,32 +1,32 @@
 import { Transform } from '../../types';
-import { memoizedGet } from '../../core/get';
 import { tokenizeValue } from '../tokenizeValue';
 
-export const borderShorthandTransform: Transform = (
-  value,
-  scale,
+export const borderShorthandTransform: Transform = ({
+  path,
+  object,
   props,
-  strict
-) => {
-  if (typeof value !== 'string') {
-    return value;
+  strict,
+  get,
+}) => {
+  if (typeof path !== 'string') {
+    return path;
   }
-  let border = memoizedGet(props?.theme?.borders || scale, value);
+  let border = get(props?.theme?.borders || object, path);
   if (border) {
     return border;
   }
-  const [[width, style, color]] = tokenizeValue(value);
-  const borderWidth = memoizedGet(
+  const [[width, style, color]] = tokenizeValue(path);
+  const borderWidth = get(
     props?.theme?.borderWidths,
     width,
     strict ? undefined : width
   );
-  const borderStyle = memoizedGet(
+  const borderStyle = get(
     props?.theme?.borderStyles,
     style,
     strict ? undefined : style
   );
-  const borderColor = memoizedGet(
+  const borderColor = get(
     props?.theme?.colors,
     color,
     strict ? undefined : color

--- a/src/props/border/test/borderShortandTransform.test.ts
+++ b/src/props/border/test/borderShortandTransform.test.ts
@@ -1,7 +1,8 @@
 import { borderShorthandTransform } from '../borderShorthandTransform';
+import { get } from '../../../core';
 
 test('transform handles rgba', () => {
   expect(
-    borderShorthandTransform('1px solid rgba(0, 0, 0, 0.1)', {}, {}, false)
+    borderShorthandTransform({ path: '1px solid rgba(0, 0, 0, 0.1)', get })
   ).toEqual('1px solid rgba(0, 0, 0, 0.1)');
 });

--- a/src/props/border/test/index.test.ts
+++ b/src/props/border/test/index.test.ts
@@ -13,8 +13,8 @@ test('returns border styles', () => {
       borders: { base: '1px solid papayawhip' },
     },
     border: '1px solid $red500',
-    borderLeft: '1px solid red500',
-    borderRight: 'base',
+    borderLeft: '1px solid $red500',
+    borderRight: '$base',
     borderBottom: '1px solid',
   });
   expect(style).toEqual({
@@ -25,7 +25,7 @@ test('returns border styles', () => {
   });
 });
 
-test.only('returns individual border styles', () => {
+test('returns individual border styles', () => {
   const style = parser({
     theme: {
       breakpoints: [],
@@ -34,23 +34,23 @@ test.only('returns individual border styles', () => {
       borderStyles: { thick: 'solid' },
       radii: { small: 5 },
     },
-    borderTopWidth: 'thin',
-    borderTopColor: 'primary',
-    borderTopStyle: 'thick',
-    borderTopLeftRadius: 'small',
-    borderTopRightRadius: 'small',
-    borderBottomWidth: 'thin',
-    borderBottomColor: 'primary',
-    borderBottomStyle: 'thick',
-    borderBottomLeftRadius: 'small',
-    borderBottomRightRadius: 'small',
-    borderRightWidth: 'thin',
-    borderRightColor: 'primary',
-    borderRightStyle: 'thick',
-    borderLeftWidth: 'thin',
-    borderLeftColor: 'primary',
-    borderLeftStyle: 'thick',
-    border: 'thin thick primary',
+    borderTopWidth: '$thin',
+    borderTopColor: '$primary',
+    borderTopStyle: '$thick',
+    borderTopLeftRadius: '$small',
+    borderTopRightRadius: '$small',
+    borderBottomWidth: '$thin',
+    borderBottomColor: '$primary',
+    borderBottomStyle: '$thick',
+    borderBottomLeftRadius: '$small',
+    borderBottomRightRadius: '$small',
+    borderRightWidth: '$thin',
+    borderRightColor: '$primary',
+    borderRightStyle: '$thick',
+    borderLeftWidth: '$thin',
+    borderLeftColor: '$primary',
+    borderLeftStyle: '$thick',
+    border: '$thin $thick $primary',
   });
   expect(style).toEqual({
     borderTopColor: 'red',
@@ -79,10 +79,10 @@ test('returns border top and bottom radii', () => {
       radii: { small: 5 },
       breakpoints: [],
     },
-    borderTopLeftRadius: 'small',
-    borderTopRightRadius: 'small',
-    borderBottomRightRadius: 'small',
-    borderBottomLeftRadius: 'small',
+    borderTopLeftRadius: '$small',
+    borderTopRightRadius: '$small',
+    borderBottomRightRadius: '$small',
+    borderBottomLeftRadius: '$small',
   });
   expect(style).toEqual({
     borderTopLeftRadius: 5,

--- a/src/props/layout/tests/index.test.ts
+++ b/src/props/layout/tests/index.test.ts
@@ -33,8 +33,8 @@ test('returns 0 from theme.sizes', () => {
       breakpoints: [],
       sizes: [24, 48, 96],
     },
-    width: 0,
-    height: 0,
+    width: '$0',
+    height: '$0',
   });
   expect(style).toEqual({
     width: 24,

--- a/src/props/position/tests/index.test.ts
+++ b/src/props/position/tests/index.test.ts
@@ -27,10 +27,10 @@ test('returns theme values', () => {
       breakpoints: [],
       space: ['0px', '4px', '8px', '16px', '32px'],
     },
-    top: 1,
-    right: -2,
-    bottom: 3,
-    left: '4',
+    top: '$1',
+    right: '-$2',
+    bottom: '$3',
+    left: '$4',
   });
   expect(style).toEqual({
     top: '4px',

--- a/src/props/positiveOrNegative.ts
+++ b/src/props/positiveOrNegative.ts
@@ -1,26 +1,31 @@
 import { Transform } from '../types';
-import { betterGet } from '../core/get';
+// import { betterGet } from '../core/get';
 
 const isNumber = (n: unknown): boolean => typeof n === 'number' && !isNaN(n);
 
-export const positiveOrNegative: Transform = (n, scale, _props, strict) => {
+export const positiveOrNegative: Transform = (get) => (
+  n,
+  scale,
+  _props,
+  strict
+) => {
   if (!isNumber(n)) {
     if (typeof n === 'string' && n.startsWith('-')) {
       const raw = n.slice(1);
-      const value = betterGet(scale, raw, raw);
+      const value = get(scale, raw, raw);
       if (isNumber(value)) {
         return value * -1;
       }
       return `-${value}`;
     }
-    return betterGet(scale, n, strict ? undefined : n);
+    return get(scale, n, strict ? undefined : n);
   }
 
   const num = n as number;
 
   const isNegative = num < 0;
   const absolute = Math.abs(num);
-  const value = betterGet(scale, absolute, strict ? undefined : absolute);
+  const value = get(scale, absolute, strict ? undefined : absolute);
   if (isNumber(value)) {
     return value * (isNegative ? -1 : 1);
   }

--- a/src/props/positiveOrNegative.ts
+++ b/src/props/positiveOrNegative.ts
@@ -1,31 +1,30 @@
 import { Transform } from '../types';
-// import { betterGet } from '../core/get';
 
 const isNumber = (n: unknown): boolean => typeof n === 'number' && !isNaN(n);
 
-export const positiveOrNegative: Transform = (get) => (
-  n,
-  scale,
-  _props,
-  strict
-) => {
-  if (!isNumber(n)) {
-    if (typeof n === 'string' && n.startsWith('-')) {
-      const raw = n.slice(1);
-      const value = get(scale, raw, raw);
+export const positiveOrNegative: Transform = ({
+  path,
+  object,
+  strict,
+  get,
+}) => {
+  if (!isNumber(path)) {
+    if (typeof path === 'string' && path.startsWith('-')) {
+      const raw = path.slice(1);
+      const value = get(object, raw, raw);
       if (isNumber(value)) {
         return value * -1;
       }
       return `-${value}`;
     }
-    return get(scale, n, strict ? undefined : n);
+    return get(object, path, strict ? undefined : path);
   }
 
-  const num = n as number;
+  const num = path as number;
 
   const isNegative = num < 0;
   const absolute = Math.abs(num);
-  const value = get(scale, absolute, strict ? undefined : absolute);
+  const value = get(object, absolute, strict ? undefined : absolute);
   if (isNumber(value)) {
     return value * (isNegative ? -1 : 1);
   }

--- a/src/props/shadow/getShadow.ts
+++ b/src/props/shadow/getShadow.ts
@@ -1,20 +1,17 @@
 import { Transform } from '../../types';
-import { memoizedGet } from '../../core/get';
 import { tokenizeValue } from '../tokenizeValue';
 
-export const getShadow: Transform = (value, _, props) => {
-  let result = memoizedGet(props?.theme?.shadows, value);
+export const getShadow: Transform = ({ path, object, get, props }) => {
+  let result = get(object, path);
   if (result) {
     return result;
   }
-  if (typeof value === 'string') {
-    return tokenizeValue(value)
+  if (typeof path === 'string') {
+    return tokenizeValue(path)
       .map((chain) =>
-        chain
-          .map((val) => memoizedGet(props?.theme?.colors, val, val))
-          .join(' ')
+        chain.map((val) => get(props?.theme?.colors, val, val)).join(' ')
       )
       .join(', ');
   }
-  return value;
+  return path;
 };

--- a/src/props/shadow/tests/getShadow.test.ts
+++ b/src/props/shadow/tests/getShadow.test.ts
@@ -1,4 +1,5 @@
 import { getShadow } from '../getShadow';
+import { get } from '../../../core';
 
 describe('getShadow', () => {
   const props = {
@@ -9,25 +10,22 @@ describe('getShadow', () => {
     },
   };
 
+  const _getShadow = (path: string) =>
+    getShadow({ path, object: {}, get, props });
+
   test('handles tokens in box-shadow', () => {
-    expect(getShadow('10px 5px 1px gray400', {}, props, false)).toEqual(
-      '10px 5px 1px #e3e3e3'
-    );
+    expect(_getShadow('10px 5px 1px $gray400')).toEqual('10px 5px 1px #e3e3e3');
 
-    expect(getShadow('1px -16px gray400', {}, props, false)).toEqual(
-      '1px -16px #e3e3e3'
-    );
+    expect(_getShadow('1px -16px $gray400')).toEqual('1px -16px #e3e3e3');
 
-    expect(getShadow('inset 1px 1em gray400', {}, props, false)).toEqual(
+    expect(_getShadow('inset 1px 1em $gray400')).toEqual(
       'inset 1px 1em #e3e3e3'
     );
 
-    expect(getShadow('60px -16px gray400', {}, props, false)).toEqual(
-      '60px -16px #e3e3e3'
-    );
+    expect(_getShadow('60px -16px $gray400')).toEqual('60px -16px #e3e3e3');
 
-    expect(
-      getShadow('60px -16px rgba(0, 242, 42, .24)', {}, props, false)
-    ).toEqual('60px -16px rgba(0, 242, 42, .24)');
+    expect(_getShadow('60px -16px rgba(0, 242, 42, .24)')).toEqual(
+      '60px -16px rgba(0, 242, 42, .24)'
+    );
   });
 });

--- a/src/props/shadow/tests/getShadow.test.ts
+++ b/src/props/shadow/tests/getShadow.test.ts
@@ -1,5 +1,5 @@
 import { getShadow } from '../getShadow';
-import { get } from '../../../core';
+import { tokenGet } from '../../../core';
 
 describe('getShadow', () => {
   const props = {
@@ -11,7 +11,7 @@ describe('getShadow', () => {
   };
 
   const _getShadow = (path: string) =>
-    getShadow({ path, object: {}, get, props });
+    getShadow({ path, object: {}, get: tokenGet, props });
 
   test('handles tokens in box-shadow', () => {
     expect(_getShadow('10px 5px 1px $gray400')).toEqual('10px 5px 1px #e3e3e3');

--- a/src/props/shadow/tests/index.test.ts
+++ b/src/props/shadow/tests/index.test.ts
@@ -25,7 +25,7 @@ const themedParser = (config: { [x: string]: any }) =>
 test('returns shadow styles', () => {
   const style = themedParser({
     textShadow: '0 -1px rgba(255, 255, 255, .25)',
-    boxShadow: 'small',
+    boxShadow: '$small',
   });
   expect(style).toEqual({
     textShadow: '0 -1px rgba(255, 255, 255, .25)',
@@ -35,7 +35,7 @@ test('returns shadow styles', () => {
 
 test('uses theme colors if it can', () => {
   const style = themedParser({
-    textShadow: '0 -1px blue.10',
+    textShadow: '0 -1px $blue.10',
     boxShadow: '0 -1px $blue.10',
   });
   expect(style).toEqual({

--- a/src/props/space/index.ts
+++ b/src/props/space/index.ts
@@ -2,37 +2,33 @@
 import { PropConfigCollection, Transform } from '../../types';
 import { positiveOrNegative } from '../positiveOrNegative';
 
-const getMargin: Transform = (get) => (value, _, props, strict) => {
+const getMargin: Transform = ({ path, object, props, strict, get }) => {
   // Not using shorthand, just a theme value, e.g, m={4}
-  if (typeof value === 'number') {
-    const result = positiveOrNegative(get)(
-      value,
-      props?.theme?.space,
-      props,
-      strict
-    );
+  if (typeof path === 'number') {
+    const result = positiveOrNegative({ path, object, props, strict, get });
     if (result) {
       return result;
     }
   }
 
-  if (typeof value === 'string') {
-    const arr = value.split(' ');
+  if (typeof path === 'string') {
+    const arr = path.split(' ');
 
     // applied to all sides, return a number or string
     // e.g., m="2" or m="$2"
     if (arr.length === 1) {
-      return positiveOrNegative(get)(value, props?.theme?.space, props, strict);
+      return positiveOrNegative({ path, object, props, strict, get });
     }
 
     return arr
       .reduce((acc: string[], curr: string) => {
-        let value = positiveOrNegative(get)(
-          curr,
-          props?.theme?.space,
+        let value = positiveOrNegative({
+          get,
+          path: curr,
+          object,
           props,
-          strict
-        );
+          strict,
+        });
 
         if (typeof value === 'number') {
           // if a number is returned, it's not converted
@@ -46,13 +42,13 @@ const getMargin: Transform = (get) => (value, _, props, strict) => {
       .join(' ');
   }
 
-  return value;
+  return path;
 };
 
-const getPadding: Transform = (get) => (value, _, props, strict) => {
+const getPadding: Transform = ({ path: value, object, props, strict, get }) => {
   // Not using shorthand, just a theme value, e.g, p={4}
   if (typeof value === 'number') {
-    const result = get(props?.theme?.space, value);
+    const result = get(object, value);
     if (result) {
       return result;
     }

--- a/src/props/space/index.ts
+++ b/src/props/space/index.ts
@@ -1,11 +1,11 @@
-import { memoizedGet } from '../../core/get';
+// import { memoizedGet } from '../../core/get';
 import { PropConfigCollection, Transform } from '../../types';
 import { positiveOrNegative } from '../positiveOrNegative';
 
-const getMargin: Transform = (value, _, props, strict) => {
+const getMargin: Transform = (get) => (value, _, props, strict) => {
   // Not using shorthand, just a theme value, e.g, m={4}
   if (typeof value === 'number') {
-    const result = positiveOrNegative(
+    const result = positiveOrNegative(get)(
       value,
       props?.theme?.space,
       props,
@@ -22,12 +22,12 @@ const getMargin: Transform = (value, _, props, strict) => {
     // applied to all sides, return a number or string
     // e.g., m="2" or m="$2"
     if (arr.length === 1) {
-      return positiveOrNegative(value, props?.theme?.space, props, strict);
+      return positiveOrNegative(get)(value, props?.theme?.space, props, strict);
     }
 
     return arr
       .reduce((acc: string[], curr: string) => {
-        let value = positiveOrNegative(
+        let value = positiveOrNegative(get)(
           curr,
           props?.theme?.space,
           props,
@@ -49,10 +49,10 @@ const getMargin: Transform = (value, _, props, strict) => {
   return value;
 };
 
-const getPadding: Transform = (value, _, props, strict) => {
+const getPadding: Transform = (get) => (value, _, props, strict) => {
   // Not using shorthand, just a theme value, e.g, p={4}
   if (typeof value === 'number') {
-    const result = memoizedGet(props?.theme?.space, value);
+    const result = get(props?.theme?.space, value);
     if (result) {
       return result;
     }
@@ -64,21 +64,13 @@ const getPadding: Transform = (value, _, props, strict) => {
     // applied to all sides, return a number or string
     // e.g., m="2" or m="$2"
     if (arr.length === 1) {
-      return memoizedGet(
-        props?.theme?.space,
-        value,
-        strict ? undefined : value
-      );
+      return get(props?.theme?.space, value, strict ? undefined : value);
     }
 
     return value
       .split(' ')
       .reduce((acc: string[], curr: string) => {
-        let value = memoizedGet(
-          props?.theme?.space,
-          curr,
-          strict ? undefined : curr
-        );
+        let value = get(props?.theme?.space, curr, strict ? undefined : curr);
         if (typeof value === 'number') {
           // if a number is returned, it's not converted
           // to a pixel value by the css parser in most libraries

--- a/src/props/space/tests/index.test.ts
+++ b/src/props/space/tests/index.test.ts
@@ -47,7 +47,7 @@ test('returns negative theme values', () => {
   expect(styles).toEqual({ margin: -8 });
 });
 
-test('returns positive theme values', () => {
+test.only('returns positive theme values', () => {
   const styles = parser({
     theme: {
       breakpoints: [],

--- a/src/props/space/tests/index.test.ts
+++ b/src/props/space/tests/index.test.ts
@@ -28,7 +28,7 @@ test('returns 0 values', () => {
 
 test('returns negative pixel values', () => {
   const styles = themedParser({ m: -2 });
-  expect(styles).toEqual({ margin: -8 });
+  expect(styles).toEqual({ margin: -2 });
 });
 
 test('returns negative em values', () => {
@@ -42,25 +42,25 @@ test('returns negative theme values', () => {
       breakpoints: [],
       space: [0, 4, 8],
     },
-    m: -2,
+    m: '-$2',
   });
   expect(styles).toEqual({ margin: -8 });
 });
 
-test.only('returns positive theme values', () => {
+test('returns positive theme values', () => {
   const styles = parser({
     theme: {
       breakpoints: [],
       space: [0, '1em', '2em'],
     },
-    m: 2,
+    m: '$2',
   });
   expect(styles).toEqual({ margin: '2em' });
 });
 
 test('returns responsive values', () => {
   const styles = themedParser({
-    m: [0, 2, 3],
+    m: ['$0', '$2', '$3'],
   });
   expect(styles).toEqual({
     margin: 0,
@@ -71,7 +71,7 @@ test('returns responsive values', () => {
 
 test('returns aliased values', () => {
   const styles = themedParser({
-    px: 2,
+    px: '$2',
   });
   expect(styles).toEqual({ paddingLeft: 8, paddingRight: 8 });
 });
@@ -82,7 +82,7 @@ test('returns string values from theme', () => {
       breakpoints: [],
       space: [0, '1em'],
     },
-    padding: 1,
+    padding: '$1',
   });
   expect(styles).toEqual({ padding: '1em' });
 });
@@ -93,7 +93,7 @@ test('returns negative string values from theme', () => {
       breakpoints: [],
       space: [0, '1em'],
     },
-    margin: -1,
+    margin: '-$1',
   });
   expect(styles).toEqual({ margin: '-1em' });
 });
@@ -104,57 +104,57 @@ test('returns values from theme object', () => {
       breakpoints: [],
       space: { sm: 1 },
     },
-    margin: 'sm',
+    margin: '$sm',
   });
   expect(styles).toEqual({ margin: 1 });
 });
 
 test('pl prop sets paddingLeft', () => {
-  const styles = themedParser({ pl: 2 });
+  const styles = themedParser({ pl: '$2' });
   expect(styles).toEqual({ paddingLeft: 8 });
 });
 
 test('pl prop sets paddingLeft 0', () => {
-  const styles = themedParser({ pl: 0 });
+  const styles = themedParser({ pl: '$0' });
   expect(styles).toEqual({ paddingLeft: 0 });
 });
 
 test('px prop overrides pl prop', () => {
   const styles = themedParser({
-    pl: 1,
-    px: 2,
+    pl: '$1',
+    px: '$2',
   });
   expect(styles).toEqual({ paddingLeft: 8, paddingRight: 8 });
 });
 
 test('py prop overrides pb prop', () => {
   const styles = themedParser({
-    pb: 1,
-    py: 2,
+    pb: '$1',
+    py: '$2',
   });
   expect(styles).toEqual({ paddingTop: 8, paddingBottom: 8 });
 });
 
 test('mx prop overrides mr prop', () => {
   const styles = themedParser({
-    mr: 1,
-    mx: 2,
+    mr: '$1',
+    mx: '$2',
   });
   expect(styles).toEqual({ marginLeft: 8, marginRight: 8 });
 });
 
 test('my prop overrides mt prop', () => {
   const styles = themedParser({
-    mt: 1,
-    my: 2,
+    mt: '$1',
+    my: '$2',
   });
   expect(styles).toEqual({ marginTop: 8, marginBottom: 8 });
 });
 
 test('margin overrides m prop', () => {
   const styles = themedParser({
-    m: 1,
-    margin: 2,
+    m: '$1',
+    margin: '$2',
   });
   expect(styles).toEqual({ margin: 8 });
 });
@@ -170,12 +170,12 @@ test('handles margin with no theme', () => {
 
 test('handles overriding margin/padding shortcut props', () => {
   const styles = themedParser({
-    m: 4,
-    mx: 3,
-    mr: 2,
-    p: 4,
-    py: 3,
-    pt: 2,
+    m: '$4',
+    mx: '$3',
+    mr: '$2',
+    p: '$4',
+    py: '$3',
+    pt: '$2',
   });
   expect(styles).toEqual({
     margin: 16,
@@ -189,12 +189,12 @@ test('handles overriding margin/padding shortcut props', () => {
 
 test('single directions override axes', () => {
   const styles = themedParser({
-    mx: 3,
-    ml: 1,
-    mr: 2,
-    px: 3,
-    pl: 1,
-    pr: 2,
+    mx: '$3',
+    ml: '$1',
+    mr: '$2',
+    px: '$3',
+    pl: '$1',
+    pr: '$2',
   });
   expect(styles).toEqual({
     marginLeft: 4,
@@ -207,9 +207,9 @@ test('single directions override axes', () => {
 test('supports object values', () => {
   const styles = themedParser({
     m: {
-      _: 0,
-      0: 1,
-      1: 2,
+      _: '$0',
+      0: '$1',
+      1: '$2',
     },
   });
   expect(styles).toEqual({
@@ -235,12 +235,12 @@ test('supports non-array breakpoints', () => {
   const styles = parser({
     theme,
     p: {
-      small: 2,
+      small: '$2',
     },
     m: {
-      _: 0,
-      small: 1,
-      medium: 2,
+      _: '$0',
+      small: '$1',
+      medium: '$2',
     },
   });
   expect(styles).toEqual({
@@ -256,12 +256,12 @@ test('supports non-array breakpoints', () => {
 });
 
 test('handles shorthand values', () => {
-  const styles = themedParser({ m: '2 4', p: '2 4' });
+  const styles = themedParser({ m: '$2 $4', p: '$2 $4' });
   expect(styles).toEqual({ margin: '8px 16px', padding: '8px 16px' });
 });
 
 test('handles shorthand negative values', () => {
-  const styles = themedParser({ m: '-2 -4' });
+  const styles = themedParser({ m: '-$2 -$4' });
   expect(styles).toEqual({ margin: '-8px -16px' });
 });
 
@@ -271,11 +271,11 @@ test('handles shorthand values ($)', () => {
 });
 
 test('handles shorthand negative values ($)', () => {
-  const styles = themedParser({ p: 2, m: '$2 $4 -$4 -$2' });
+  const styles = themedParser({ p: '$2', m: '$2 $4 -$4 -$2' });
   expect(styles).toEqual({ padding: 8, margin: '8px 16px -16px -8px' });
 });
 
 test('padding does not handle negative values, just passes through', () => {
-  const styles = themedParser({ paddingLeft: -1, p: '1 -2 -$2 $1' });
+  const styles = themedParser({ paddingLeft: -1, p: '$1 -2 -$2 $1' });
   expect(styles).toEqual({ paddingLeft: -1, padding: '4px -2 -$2 4px' });
 });

--- a/src/props/styled-system-layout/index.ts
+++ b/src/props/styled-system-layout/index.ts
@@ -1,16 +1,15 @@
 import { PropConfigCollection, Transform } from '../../types';
-import { get } from '../../core/get';
 import { Property } from 'csstype';
 
 const isNumber = (n: unknown) => typeof n === 'number' && !isNaN(n);
 
-const getWidth: Transform = (value, scale) => {
-  let defaultValue = value;
-  if (isNumber(value)) {
-    const n = value as number;
-    defaultValue = n > 1 ? value : `${n * 100}%`;
+const getWidth: Transform = ({ path, object, get }) => {
+  let defaultValue = path;
+  if (isNumber(path)) {
+    const n = path as number;
+    defaultValue = n > 1 ? path : `${n * 100}%`;
   }
-  return get(scale, value, defaultValue);
+  return get(object, path, defaultValue);
 };
 
 export const layout: PropConfigCollection = {

--- a/src/props/styled-system-layout/tests/index.test.ts
+++ b/src/props/styled-system-layout/tests/index.test.ts
@@ -33,8 +33,8 @@ test('returns 0 from theme.sizes', () => {
       breakpoints: [],
       sizes: [24, 48, 96],
     },
-    width: 0,
-    height: 0,
+    width: '$0',
+    height: '$0',
   });
   expect(style).toEqual({
     width: 24,

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,15 +94,21 @@ export interface StyleFunction {
   (propertyConfig: PropertyConfig): SystemConfig;
 }
 
-export type Transform = (
-  get: Get
-) => (
-  path: any,
-  object: any,
-  props: Props,
-  strict: boolean,
-  undef?: undefined
-) => any;
+export interface Transform {
+  ({
+    path,
+    object,
+    props,
+    strict,
+    get,
+  }: {
+    path?: any;
+    object?: any;
+    props?: Props;
+    strict?: boolean;
+    get: Get;
+  }): any;
+}
 
 export type PropertyConfig = {
   properties?: Array<keyof CSSProperties>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,17 @@ export interface SystemConfig {
   defaultScale?: unknown;
 }
 
+export interface Get {
+  (obj?: any, path?: any, fallback?: any): any;
+}
+
+export interface StyleFunction {
+  (propertyConfig: PropertyConfig): SystemConfig;
+}
+
 export type Transform = (
+  get: Get
+) => (
   path: any,
   object: any,
   props: Props,
@@ -100,6 +110,7 @@ export type PropertyConfig = {
   scale?: string;
   defaultScale?: Array<string | number>;
   transform?: Transform;
+  get?: Get;
 };
 
 export interface PropConfigCollection {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,6 +2795,11 @@ eslint-plugin-jsx-a11y@^6.2.3:
     jsx-ast-utils "^2.4.1"
     language-tags "^1.0.5"
 
+eslint-plugin-no-only-tests@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
+  integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
+
 eslint-plugin-prettier@^3.1.0, eslint-plugin-prettier@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"


### PR DESCRIPTION
Adds support for supporting a custom `get` function.

```js
const system = createSystem({get: customGet})
```

This may unlock the possibility of narrowing down theme access to `$` prefixed values by default and exclusively, instead of simultaneously supporting both `$` prefix and not. But then with a custom get function, users looking for styled-system compatibility would have the ability to create a custom get function to get that.