### PR TITLE
Add new Transition prop group

### DIFF
--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -23,6 +23,7 @@ test('package has expected exports', () => {
       "shouldForwardProp",
       "space",
       "styledSystemLayout",
+      "transition",
       "typography",
     ]
   `);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
   FlexItemProps,
   FlexContainerProps,
   FlexboxProps,
+  TransitionProps,
   AllSystemProps,
   PropConfigCollection,
   Theme,

--- a/src/props/index.ts
+++ b/src/props/index.ts
@@ -7,5 +7,6 @@ export * from './layout';
 export * from './position';
 export * from './shadow';
 export * from './space';
+export * from './transition';
 export * from './typography';
 export { layout as styledSystemLayout } from './styled-system-layout';

--- a/src/props/transition/index.ts
+++ b/src/props/transition/index.ts
@@ -6,6 +6,9 @@ const parseTransition: Transform = ({ path, object, get, strict }) => {
   if (result) {
     return result;
   }
+
+  // '$tokenValue, $anotherTokenValue'
+  // '$tokenValue, property duration easing'
   if (typeof path === 'string') {
     const transitions = tokenizeValue(path);
     result = transitions
@@ -18,6 +21,7 @@ const parseTransition: Transform = ({ path, object, get, strict }) => {
       .join(', ');
     return result;
   }
+
   return path;
 };
 

--- a/src/props/transition/index.ts
+++ b/src/props/transition/index.ts
@@ -1,0 +1,40 @@
+import { PropConfigCollection, Transform } from '../../types';
+import { tokenizeValue } from '../tokenizeValue';
+
+const parseTransition: Transform = ({ path, object, get, strict }) => {
+  let result = get(object, path);
+  if (result) {
+    return result;
+  }
+  if (typeof path === 'string') {
+    const transitions = tokenizeValue(path);
+    result = transitions
+      .map((transition) => {
+        if (transition.length === 1) {
+          return get(object, transition[0], strict ? undefined : transition[0]);
+        }
+        return transition.join(' ');
+      })
+      .join(', ');
+    return result;
+  }
+  return path;
+};
+
+export const transition: PropConfigCollection = {
+  transition: {
+    property: 'transition',
+    scale: 'transitions',
+    transform: parseTransition,
+  },
+  transitionDuration: {
+    property: 'transitionDuration',
+    scale: 'transitionDurations',
+  },
+  transitionTimingFunction: {
+    property: 'transitionTimingFunction',
+    scale: 'transitionTimingFunctions',
+  },
+  transitionProperty: true,
+  transitionDelay: true,
+};

--- a/src/props/transition/tests/index.test.ts
+++ b/src/props/transition/tests/index.test.ts
@@ -1,0 +1,58 @@
+import { transition } from '..';
+import { createSystem } from '../../../core';
+
+const system = createSystem();
+
+const parser = system(transition);
+
+test('returns transition styles', () => {
+  const style = parser({
+    theme: { breakpoints: [] },
+    transition: 'color 1.5s ease, background-color .5s ease-out',
+  });
+  expect(style).toEqual({
+    transition: 'color 1.5s ease, background-color .5s ease-out',
+  });
+});
+
+test('parses theme properties', () => {
+  const theme = {
+    breakpoints: [],
+    transitions: { a: 'color 1.5s ease', b: 'opacity .5s ease-out' },
+    transitionDurations: { 100: '100ms', 200: '200ms' },
+    transitionTimingFunctions: { standard: 'ease', relaxed: 'ease-out' },
+  };
+  const styleA = parser({
+    theme,
+    transition: '$a, $b',
+    transitionDuration: '$200',
+    transitionTimingFunction: '$standard',
+  });
+  expect(styleA).toEqual({
+    transition: 'color 1.5s ease, opacity .5s ease-out',
+    transitionDuration: '200ms',
+    transitionTimingFunction: 'ease',
+  });
+
+  const styleB = parser({
+    theme,
+    transition: '$a, background-color 2s ease-in-out',
+  });
+  expect(styleB).toEqual({
+    transition: 'color 1.5s ease, background-color 2s ease-in-out',
+  });
+
+  const styleC = parser({
+    theme,
+    transitionProperty: 'color, opacity',
+    transitionDuration: '$100',
+    transitionTimingFunction: '$relaxed',
+    transitionDelay: '1s',
+  });
+  expect(styleC).toEqual({
+    transitionProperty: 'color, opacity',
+    transitionDuration: '100ms',
+    transitionTimingFunction: 'ease-out',
+    transitionDelay: '1s',
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,9 @@ type TokenScales =
   | 'lineHeights'
   | 'fonts'
   | 'radii'
+  | 'transitions'
+  | 'transitionDurations'
+  | 'transitionTimingFunctions'
   | 'breakpoints';
 
 export interface Theme {
@@ -355,6 +358,24 @@ export interface TypographyProps<
   fontStyle?: SystemProp<P.FontStyle>;
 }
 
+export interface TransitionProps<
+  PrefixOption extends PrefixOptions = PrefixDefault
+> {
+  transition?: MaybeToken<P.Transition, PrefixOption, 'transitions'>;
+  transitionDuration?: MaybeToken<
+    P.TransitionDuration,
+    PrefixOption,
+    'transitionDurations'
+  >;
+  transitionTimingFunction?: MaybeToken<
+    P.TransitionTimingFunction,
+    PrefixOption,
+    'transitionTimingFunctions'
+  >;
+  transitionProperty?: SystemProp<P.TransitionProperty>;
+  transitionDelay?: SystemProp<P.TransitionDelay>;
+}
+
 export interface AllSystemProps<
   PrefixOption extends PrefixOptions = PrefixDefault
 > extends ColorProps<PrefixOption>,
@@ -365,7 +386,8 @@ export interface AllSystemProps<
     ShadowProps<PrefixOption>,
     PositionProps<PrefixOption>,
     GridProps<PrefixOption>,
-    FlexboxProps {}
+    FlexboxProps,
+    TransitionProps<PrefixOption> {}
 
 export type SystemPropsTheme = Partial<
   Record<TokenScales, Record<string, string | number>>


### PR DESCRIPTION
Fixes #23 

Decided that for now, we shouldn't add the animation group. I don't think it's frequently tied to theme scales. For `transition`, I was thinking that we could parse the individual elements for the property, timing-fuction, durations, etc, but I don't think we can reliably do so since the order of each element isn't fixed. The only thing that is consistently known is that the first time number is the duration, and the second number is delay. However, we can't reliably predict if the timing-function comes before the duration or vice versa. 

For now, this will simply parse for the `transitions` theme scale, and can support multiple comma-separated transitions. 